### PR TITLE
Batch requests within a specified interval

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "testonly:cover": "babel-node node_modules/.bin/isparta cover --root src --report html _mocha -- $npm_package_options_mocha",
     "testonly:coveralls": "babel-node node_modules/.bin/isparta cover --root src --report lcovonly _mocha -- $npm_package_options_mocha && cat ./coverage/lcov.info | coveralls",
     "preversion": ". ./resources/checkgit.sh && npm test",
-    "prepublish": ". ./resources/prepublish.sh"
+    "prepublish": ". ./resources/prepublish.sh",
+    "postinstall": "npm run build && cp dist/* ."
   },
   "files": [
     "index.js",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -91,6 +91,14 @@ declare namespace DataLoader {
      */
     maxBatchSize?: number;
 
+
+    /**
+     * Default `0`. Instead of batching requests within the same tick,
+     * batch all requests that occur within `batchIntervalMs` of each other.
+     * Note that this adds always adds a latency of `batchIntervalMs` to resolution.
+     */
+    batchIntervalMs?: number;
+
     /**
      * Default `true`. Set to `false` to disable memoization caching,
      * instead creating a new Promise and new key in the `batchLoadFn` for every


### PR DESCRIPTION
Addresses https://github.com/facebook/dataloader/issues/58

Adds an option to wait `batchIntervalMs` before dispatching the queue of requests, so that you can batch requests across ticks