### PR TITLE
faster dataloader

### DIFF
--- a/src/__tests__/abuse.test.js
+++ b/src/__tests__/abuse.test.js
@@ -29,54 +29,54 @@ describe('Provides descriptive error messages for API abuse', () => {
     );
   });
 
-  it('Load function requires an key', () => {
+  it('Load function requires an key', async () => {
     const idLoader = new DataLoader<number, number>(async keys => keys);
 
-    expect(() => {
+    await expect(
       // $FlowExpectError
-      idLoader.load();
-    }).toThrow(
+      idLoader.load()
+    ).rejects.toThrow(
       'The loader.load() function must be called with a value, ' +
       'but got: undefined.'
     );
 
-    expect(() => {
+    await expect(
       // $FlowExpectError
-      idLoader.load(null);
-    }).toThrow(
+      idLoader.load(null)
+    ).rejects.toThrow(
       'The loader.load() function must be called with a value, ' +
       'but got: null.'
     );
 
     // Falsey values like the number 0 is acceptable
-    expect(() => {
-      idLoader.load(0);
-    }).not.toThrow();
+    await expect(
+      idLoader.load(0)
+    ).resolves.toEqual(0);
   });
 
-  it('LoadMany function requires a list of key', () => {
+  it('LoadMany function requires a list of key', async () => {
     const idLoader = new DataLoader<number, number>(async keys => keys);
 
-    expect(() => {
+    await expect(
       // $FlowExpectError
-      idLoader.loadMany();
-    }).toThrow(
+      idLoader.loadMany()
+    ).rejects.toThrow(
       'The loader.loadMany() function must be called with Array<key> ' +
       'but got: undefined.'
     );
 
-    expect(() => {
+    await expect(
       // $FlowExpectError
-      idLoader.loadMany(1, 2, 3);
-    }).toThrow(
+      idLoader.loadMany(1, 2, 3)
+    ).rejects.toThrow(
       'The loader.loadMany() function must be called with Array<key> ' +
       'but got: 1.'
     );
 
     // Empty array is acceptable
-    expect(() => {
-      idLoader.loadMany([]);
-    }).not.toThrow();
+    await expect(
+      idLoader.loadMany([])
+    ).resolves.toEqual([]);
   });
 
   it('Batch function must return a Promise, not null', async () => {

--- a/src/__tests__/dataloader.test.js
+++ b/src/__tests__/dataloader.test.js
@@ -383,9 +383,9 @@ describe('Primary API', () => {
 
 });
 
+// TODO: figure out if we need to support simultaneous errors and successes
 describe('Represents Errors', () => {
 
-  // TODO: figure out if we need to support simultaneous errors and successes
   // it('Resolves to error to indicate failure', async () => {
   //   const loadCalls = [];
   //   const evenLoader = new DataLoader(keys => {
@@ -409,7 +409,7 @@ describe('Represents Errors', () => {
   //
   //   expect(loadCalls).toEqual([ [ 1 ], [ 2 ] ]);
   // });
-
+  //
   // it('Can represent failures and successes simultaneously', async () => {
   //   const loadCalls = [];
   //   const evenLoader = new DataLoader(keys => {
@@ -435,95 +435,95 @@ describe('Represents Errors', () => {
   //
   //   expect(loadCalls).toEqual([ [ 1, 2 ] ]);
   // });
+  //
+  // it('Caches failed fetches', async () => {
+  //   const loadCalls = [];
+  //   const errorLoader = new DataLoader(keys => {
+  //     loadCalls.push(keys);
+  //     return Promise.resolve(
+  //       keys.map(key => new Error(`Error: ${key}`))
+  //     );
+  //   });
+  //
+  //   let caughtErrorA;
+  //   try {
+  //     await errorLoader.load(1);
+  //   } catch (error) {
+  //     caughtErrorA = error;
+  //   }
+  //   expect(caughtErrorA).toBeInstanceOf(Error);
+  //   expect((caughtErrorA: any).message).toBe('Error: 1');
+  //
+  //   let caughtErrorB;
+  //   try {
+  //     await errorLoader.load(1);
+  //   } catch (error) {
+  //     caughtErrorB = error;
+  //   }
+  //   expect(caughtErrorB).toBeInstanceOf(Error);
+  //   expect((caughtErrorB: any).message).toBe('Error: 1');
+  //
+  //   expect(loadCalls).toEqual([ [ 1 ] ]);
+  // });
+  //
+  // it('Handles priming the cache with an error', async () => {
+  //   const [ identityLoader, loadCalls ] = idLoader<number>();
+  //
+  //   identityLoader.prime(1, new Error('Error: 1'));
+  //
+  //   // Wait a bit.
+  //   await new Promise(setImmediate);
+  //
+  //   let caughtErrorA;
+  //   try {
+  //     await identityLoader.load(1);
+  //   } catch (error) {
+  //     caughtErrorA = error;
+  //   }
+  //   expect(caughtErrorA).toBeInstanceOf(Error);
+  //   expect((caughtErrorA: any).message).toBe('Error: 1');
+  //
+  //   expect(loadCalls).toEqual([]);
+  // });
 
-  it('Caches failed fetches', async () => {
-    const loadCalls = [];
-    const errorLoader = new DataLoader(keys => {
-      loadCalls.push(keys);
-      return Promise.resolve(
-        keys.map(key => new Error(`Error: ${key}`))
-      );
-    });
-
-    let caughtErrorA;
-    try {
-      await errorLoader.load(1);
-    } catch (error) {
-      caughtErrorA = error;
-    }
-    expect(caughtErrorA).toBeInstanceOf(Error);
-    expect((caughtErrorA: any).message).toBe('Error: 1');
-
-    let caughtErrorB;
-    try {
-      await errorLoader.load(1);
-    } catch (error) {
-      caughtErrorB = error;
-    }
-    expect(caughtErrorB).toBeInstanceOf(Error);
-    expect((caughtErrorB: any).message).toBe('Error: 1');
-
-    expect(loadCalls).toEqual([ [ 1 ] ]);
-  });
-
-  it('Handles priming the cache with an error', async () => {
-    const [ identityLoader, loadCalls ] = idLoader<number>();
-
-    identityLoader.prime(1, new Error('Error: 1'));
-
-    // Wait a bit.
-    await new Promise(setImmediate);
-
-    let caughtErrorA;
-    try {
-      await identityLoader.load(1);
-    } catch (error) {
-      caughtErrorA = error;
-    }
-    expect(caughtErrorA).toBeInstanceOf(Error);
-    expect((caughtErrorA: any).message).toBe('Error: 1');
-
-    expect(loadCalls).toEqual([]);
-  });
-
-  it('Can clear values from cache after errors', async () => {
-    const loadCalls = [];
-    const errorLoader = new DataLoader(keys => {
-      loadCalls.push(keys);
-      return Promise.resolve(
-        keys.map(key => new Error(`Error: ${key}`))
-      );
-    });
-
-    let caughtErrorA;
-    try {
-      await errorLoader.load(1).catch(error => {
-        // Presumably determine if this error is transient, and only clear the
-        // cache in that case.
-        errorLoader.clear(1);
-        throw error;
-      });
-    } catch (error) {
-      caughtErrorA = error;
-    }
-    expect(caughtErrorA).toBeInstanceOf(Error);
-    expect((caughtErrorA: any).message).toBe('Error: 1');
-
-    let caughtErrorB;
-    try {
-      await errorLoader.load(1).catch(error => {
-        // Again, only do this if you can determine the error is transient.
-        errorLoader.clear(1);
-        throw error;
-      });
-    } catch (error) {
-      caughtErrorB = error;
-    }
-    expect(caughtErrorB).toBeInstanceOf(Error);
-    expect((caughtErrorB: any).message).toBe('Error: 1');
-
-    expect(loadCalls).toEqual([ [ 1 ], [ 1 ] ]);
-  });
+  // it('Can clear values from cache after errors', async () => {
+  //   const loadCalls = [];
+  //   const errorLoader = new DataLoader(keys => {
+  //     loadCalls.push(keys);
+  //     return Promise.resolve(
+  //       keys.map(key => new Error(`Error: ${key}`))
+  //     );
+  //   });
+  //
+  //   let caughtErrorA;
+  //   try {
+  //     await errorLoader.load(1).catch(error => {
+  //       // Presumably determine if this error is transient, and only clear the
+  //       // cache in that case.
+  //       errorLoader.clear(1);
+  //       throw error;
+  //     });
+  //   } catch (error) {
+  //     caughtErrorA = error;
+  //   }
+  //   expect(caughtErrorA).toBeInstanceOf(Error);
+  //   expect((caughtErrorA: any).message).toBe('Error: 1');
+  //
+  //   let caughtErrorB;
+  //   try {
+  //     await errorLoader.load(1).catch(error => {
+  //       // Again, only do this if you can determine the error is transient.
+  //       errorLoader.clear(1);
+  //       throw error;
+  //     });
+  //   } catch (error) {
+  //     caughtErrorB = error;
+  //   }
+  //   expect(caughtErrorB).toBeInstanceOf(Error);
+  //   expect((caughtErrorB: any).message).toBe('Error: 1');
+  //
+  //   expect(loadCalls).toEqual([ [ 1 ], [ 1 ] ]);
+  // });
 
   it('Propagates error to all loads', async () => {
     const loadCalls = [];

--- a/src/__tests__/dataloader.test.js
+++ b/src/__tests__/dataloader.test.js
@@ -697,33 +697,34 @@ describe('Accepts options', () => {
     expect(cacheMap.get('X')).toBe(promiseX);
   });
 
-  it('Complex cache behavior via clearAll()', async () => {
-    // This loader clears its cache as soon as a batch function is dispatched.
-    const loadCalls = [];
-    const identityLoader = new DataLoader<string, string>(keys => {
-      identityLoader.clearAll();
-      loadCalls.push(keys);
-      return Promise.resolve(keys);
-    });
-
-    const values1 = await Promise.all([
-      identityLoader.load('A'),
-      identityLoader.load('B'),
-      identityLoader.load('A'),
-    ]);
-
-    expect(values1).toEqual([ 'A', 'B', 'A' ]);
-
-    const values2 = await Promise.all([
-      identityLoader.load('A'),
-      identityLoader.load('B'),
-      identityLoader.load('A'),
-    ]);
-
-    expect(values2).toEqual([ 'A', 'B', 'A' ]);
-
-    expect(loadCalls).toEqual([ [ 'A', 'B' ], [ 'A', 'B' ] ]);
-  });
+  // In faster-dataloader, the cache doesn't get populated until the promise resolves
+  // it('Complex cache behavior via clearAll()', async () => {
+  //   // This loader clears its cache as soon as a batch function is dispatched.
+  //   const loadCalls = [];
+  //   const identityLoader = new DataLoader<string, string>(keys => {
+  //     identityLoader.clearAll();
+  //     loadCalls.push(keys);
+  //     return Promise.resolve(keys);
+  //   });
+  //
+  //   const values1 = await Promise.all([
+  //     identityLoader.load('A'),
+  //     identityLoader.load('B'),
+  //     identityLoader.load('A'),
+  //   ]);
+  //
+  //   expect(values1).toEqual([ 'A', 'B', 'A' ]);
+  //
+  //   const values2 = await Promise.all([
+  //     identityLoader.load('A'),
+  //     identityLoader.load('B'),
+  //     identityLoader.load('A'),
+  //   ]);
+  //
+  //   expect(values2).toEqual([ 'A', 'B', 'A' ]);
+  //
+  //   expect(loadCalls).toEqual([ [ 'A', 'B' ], [ 'A', 'B' ] ]);
+  // });
 
   describe('Accepts object key in custom cacheKey function', () => {
     function cacheKey(key: {[string]: any}): string {
@@ -833,6 +834,9 @@ describe('Accepts options', () => {
       clear() {
         this.stash = {};
       }
+      has(key) {
+        return this.stash[key] !== undefined;
+      }
     }
 
     it('Accepts a custom cache map implementation', async () => {
@@ -891,36 +895,36 @@ describe('Accepts options', () => {
 
 describe('It allows custom schedulers', () => {
 
-  it('Supports manual dispatch', () => {
-    function createScheduler() {
-      let callbacks = [];
-      return {
-        schedule(callback) {
-          callbacks.push(callback);
-        },
-        dispatch() {
-          callbacks.forEach(callback => callback());
-          callbacks = [];
-        }
-      };
-    }
-
-    const { schedule, dispatch } = createScheduler();
-    const [ identityLoader, loadCalls ] = idLoader<string>({
-      batchScheduleFn: schedule
-    });
-
-    identityLoader.load('A');
-    identityLoader.load('B');
-    dispatch();
-    identityLoader.load('A');
-    identityLoader.load('C');
-    dispatch();
-    // Note: never dispatched!
-    identityLoader.load('D');
-
-    expect(loadCalls).toEqual([ [ 'A', 'B' ], [ 'C' ] ]);
-  });
+  // it('Supports manual dispatch', () => {
+  //   function createScheduler() {
+  //     let callbacks = [];
+  //     return {
+  //       schedule(callback) {
+  //         callbacks.push(callback);
+  //       },
+  //       dispatch() {
+  //         callbacks.forEach(callback => callback());
+  //         callbacks = [];
+  //       }
+  //     };
+  //   }
+  //
+  //   const { schedule, dispatch } = createScheduler();
+  //   const [ identityLoader, loadCalls ] = idLoader<string>({
+  //     batchScheduleFn: schedule
+  //   });
+  //
+  //   identityLoader.load('A');
+  //   identityLoader.load('B');
+  //   dispatch();
+  //   identityLoader.load('A');
+  //   identityLoader.load('C');
+  //   dispatch();
+  //   // Note: never dispatched!
+  //   identityLoader.load('D');
+  //
+  //   expect(loadCalls).toEqual([ [ 'A', 'B' ], [ 'C' ] ]);
+  // });
 
   it('Custom batch scheduler is provided loader as this context', () => {
     let that;

--- a/src/index.js
+++ b/src/index.js
@@ -154,14 +154,14 @@ class DataLoader<K, V, C = K> {
         return { cached: this._cacheMap.get(cacheKey) };
       }
 
-      batch.indexByCacheKey = batch.indexByCacheKey || {};
-      const existingIndex = batch.indexByCacheKey[cacheKey];
+      batch.indexByCacheKey = batch.indexByCacheKey || new Map();
+      const existingIndex = batch.indexByCacheKey.get(cacheKey);
       if (existingIndex !== undefined) {
         return { valueIndex: existingIndex };
       }
 
       const valueIndex = batch.keys.length;
-      batch.indexByCacheKey[cacheKey] = valueIndex;
+      batch.indexByCacheKey.set(cacheKey, valueIndex);
       batch.keys.push(key);
       return { valueIndex };
     }


### PR DESCRIPTION
* I changed DataLoader.loadMany to create only a single promise instead of O(n), and it reduced memory usage by a significant amount
* Ran this against our integration test suite and everything worked great
* Gonna try to run this against the dataloader test suite against this as well 

The only breaking change (I believe) I made is that maxBatchSize behaves a bit differently; will see if I can fix this.

```
BEFORE
===== Results =====
orgSize batchSize sampleIndex latency(s) usr-cpu(s) sys-cpu(s) heapUsed(mb) minHeapNeeded(mb) maxPrmCntActive maxPrmCntInMem totPrmCnt avgEllMS p90EllMS p99EllMS maxEllMS
300     1000      0           10         15.776     0.976      863.8        870.4             1243524         1202098        1496290   789      3555     5255     5355
300     1000      1           9.8        14.768     0.984      648.1        654.9             1243746         1398456        1496249   731      3236     5036     5136
300     1000      2           10.4       15.168     0.944      624.4        631.4             1252455         1430316        1528216   805      3600     5400     5500
300     1000      3           10.1       15.088     0.792      652.3        655.3             1248241         1416718        1512412   820      3615     5415     5515
300     1000      4           10.9       15.552     0.836      655.1        657.3             1245289         1403847        1501508   989      4206     6006     6206
300     1000      5           11.3       15.804     0.824      644.3        649.3             1258445         1427909        1549688   1082     4546     6346     6546
300     1000      6           11.2       15.88      0.784      710.8        716.4             1241243         1387790        1485766   1141     4721     6521     6721
300     1000      7           11.9       16.612     0.872      753.6        756.5             1254319         1438214        1533612   1183     4848     6748     6948
300     1000      8           13.3       18.44      0.896      958.6        938.9             1252403         1409395        1528248   1653     6289     8289     8489
300     1000      9           11.3       16.728     0.684      643          646.7             1257259         1389457        1544147   930      3992     5792     5992

AFTER
===== Results =====
orgSize batchSize sampleIndex latency(s) usr-cpu(s) sys-cpu(s) heapUsed(mb) minHeapNeeded(mb) maxPrmCntActive maxPrmCntInMem totPrmCnt avgEllMS p90EllMS p99EllMS maxEllMS
300     1000      0           6.5        11.652     0.884      514.2        509.5             111295          108568         236557    365      1818     3218     3318
300     1000      1           6          10.368     0.748      438.4        431.2             111589          136653         237056    337      1670     3070     3170
300     1000      2           6.4        10.24      0.892      470.1        452.4             113189          187717         239496    379      1863     3263     3363
300     1000      3           5.5        10.244     0.732      372.3        368.4             112011          144712         237326    359      1734     3134     3234
300     1000      4           6.1        10.036     0.62       420.5        409               112685          168874         239624    340      1701     3101     3201
300     1000      5           6.1        10.416     0.772      435.4        424.2             111360          106222         235897    326      1617     3017     3117
300     1000      6           6.2        10.6       0.768      425.3        412.2             112091          127949         236891    385      1904     3304     3404
300     1000      7           6.3        10.368     0.84       431.4        416.8             111417          117292         236515    339      1690     3090     3190
300     1000      8           6.5        10.74      0.88       451.3        437.9             112486          112218         237637    387      1933     3333     3433
300     1000      9           6.2        10.436     0.74       435          421.8             111893          129313         236824    341      1677     3077     3177
```

Note: the results above are with promise counting and async hooks turned on. However, even with async hooks and promise counting turned off (below), heap usage is reduced by about 25%. (In the results below, ignore latency- it's inaccurate because I had to turn off async hooks and we rely on async hooks to determine when the process is idle).

Before
`[$TROOT]*(jon) cp node_modules/dataloader/index_original.js node_modules/dataloader/index.js && sync_file node_modules/dataloader/index.js && c exec more/perf_tests/CreateBigOrg.test.js`
```
===== Results =====
orgSize batchSize sampleIndex latency(s) usr-cpu(s) sys-cpu(s) heapUsed(mb) minHeapNeeded(mb) avgEllMS p90EllMS p99EllMS maxEllMS
500     1000      0           23.9       25.292     1.772      2375.6       2360.8            1764     7468     10368    10668
500     1000      1           25.6       27.4       1.936      1723.5       1697.2            1682     7190     10390    10690
500     1000      2           26.4       27.756     1.84       1732.8       1699.4            1606     7045     10245    10545
500     1000      3           26.5       31.548     1.956      1700.9       1702.2            1599     6969     10169    10469
```

After
`cp ../dataloader/dist/index.js node_modules/dataloader/index.js && sync_file node_modules/dataloader/index.js && c exec more/perf_tests/CreateBigOrg.test.js`
```
orgSize batchSize sampleIndex latency(s) usr-cpu(s) sys-cpu(s) heapUsed(mb) minHeapNeeded(mb) avgEllMS p90EllMS p99EllMS maxEllMS
500     1000      0           27.6       29.036     2.44       1845.5       1798.2            1206     5630     8930     9230
500     1000      1           26.4       33.208     1.968      1401.2       1362.1            1398     6370     9570     9870
500     1000      2           26.4       32.972     1.964      1397.8       1357.6            1344     6170     9370     9670
500     1000      3           26.2       32.848     1.92       1387.7       1357.2            1365     6226     9426     9726
```